### PR TITLE
Fix targeted lint warnings in components

### DIFF
--- a/src/components/ArtCard.tsx
+++ b/src/components/ArtCard.tsx
@@ -1,6 +1,9 @@
 // file: src/components/ArtCard.tsx
 "use client";
 
+import Image from "next/image";
+import type { CSSProperties } from "react";
+
 type Color = "duo" | "pink" | "green";
 
 export type ArtCardProps = {
@@ -24,13 +27,18 @@ export default function ArtCard({
   className = "",
   jitter,
 }: ArtCardProps) {
-  const styleVars = {
+  type StyleVars = CSSProperties &
+    Partial<
+      Record<"--tilt" | "--jitter-left" | "--jitter-right" | "--jitter-bottom", string>
+    >;
+
+  const styleVars: StyleVars = {
     // CSS-Variablen für Rotation/Jitter
     // werden auf dem Frame-Wrapper gesetzt
-    ...(tiltDeg !== undefined ? { ["--tilt" as any]: `${tiltDeg}deg` } : {}),
-    ...(jitter?.left   ? { ["--jitter-left" as any]: jitter.left }   : {}),
-    ...(jitter?.right  ? { ["--jitter-right" as any]: jitter.right } : {}),
-    ...(jitter?.bottom ? { ["--jitter-bottom" as any]: jitter.bottom } : {}),
+    ...(tiltDeg !== undefined ? { "--tilt": `${tiltDeg}deg` } : {}),
+    ...(jitter?.left ? { "--jitter-left": jitter.left } : {}),
+    ...(jitter?.right ? { "--jitter-right": jitter.right } : {}),
+    ...(jitter?.bottom ? { "--jitter-bottom": jitter.bottom } : {}),
   };
 
   const frameClass =
@@ -43,7 +51,7 @@ export default function ArtCard({
 
   return (
     <div className={`art-card ${className}`}>
-      <div className="art-card__frame" style={styleVars as React.CSSProperties}>
+      <div className="art-card__frame" style={styleVars}>
         <div className={frameClass} {...dataColor}>
           {/* ======= Das eigentliche Markup der vier Rahmen-Seiten ======= */}
           <div className="frame-top frame-side" />
@@ -53,7 +61,14 @@ export default function ArtCard({
 
           {/* ======= Bild (gegenrotiert) ======= */}
           <div className="art-card__inner">
-            <img className="art-card__img" src={src} alt={alt} />
+            <Image
+              className="art-card__img"
+              src={src}
+              alt={alt}
+              width={1200}
+              height={1200}
+              sizes="(min-width: 768px) 33vw, 100vw"
+            />
           </div>
         </div>
       </div>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,4 +1,5 @@
-﻿'use client';
+'use client';
+import Image from 'next/image';
 import { motion } from 'framer-motion';
 
 const mockArtworks = [
@@ -19,7 +20,14 @@ export default function Gallery() {
           className="relative bg-white p-4 rounded-lg shadow-lg transform rotate-1"
           style={{ border: '6px solid transparent', borderImage: 'url(/textures/crayon-green.png) 30 round' }}
         >
-          <img src={art.src} alt={art.title} className="w-full h-auto rounded" />
+          <Image
+            src={art.src}
+            alt={art.title}
+            width={300}
+            height={300}
+            className="w-full h-auto rounded"
+            sizes="(min-width: 768px) 33vw, 100vw"
+          />
           <p className="mt-2 text-[var(--bart-secondary-gray)]">
             {art.title}, 2025 – {art.artist}
           </p>
@@ -31,4 +39,3 @@ export default function Gallery() {
     </div>
   );
 }
-

--- a/src/components/GalleryCard.tsx
+++ b/src/components/GalleryCard.tsx
@@ -1,5 +1,6 @@
-﻿'use client';
+'use client';
 
+import Image from 'next/image';
 import { motion } from 'framer-motion';
 
 export interface GalleryCardProps {
@@ -19,7 +20,14 @@ export default function GalleryCard({ src, title, artist, layoutId }: GalleryCar
       transition={{ duration: 0.5 }}
       layoutId={layoutId ?? `card-${src}`} /* stabil durch src */
     >
-      <img src={src} alt={title} className="w-full h-auto rounded" />
+      <Image
+        src={src}
+        alt={title}
+        width={1200}
+        height={1200}
+        className="w-full h-auto rounded"
+        sizes="(min-width: 1280px) 25vw, (min-width: 768px) 33vw, 100vw"
+      />
       <p className="mt-2 text-sm text-[var(--bart-secondary-gray)]">
         {title}, 2025 – {artist}
       </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,12 +2,10 @@
 // file: src/components/Hero.tsx (unchanged from previous delivery)
 // ==============================
 "use client";
-import { track } from "@/lib/analytics";
 import Section from "./Section";
 
 
 export default function Hero() {
-  const onHover = () => track("tooltip_seen_soon", { source: "hero_cta" });
   return (
     <div className="relative z-[1]">
       <Section className="py-10 sm:py-14 md:py-16">

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 
-type AsProp = keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>;
+type AsProp = keyof JSX.IntrinsicElements | React.JSXElementConstructor<unknown>;
 type Props<T extends AsProp> = {
   id?: string;
   className?: string;
@@ -11,7 +11,7 @@ function SectionInner<T extends AsProp = "section">(
   { id, className = "", as, children, ...rest }: Props<T>,
   ref: React.ForwardedRef<Element>
 ) {
-  const Tag = (as || "section") as any;
+  const Tag = (as || "section") as React.ElementType;
   return (
     <Tag
       ref={ref}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,5 +1,6 @@
 // file: src/components/SiteFooter.tsx  (UPDATE — icons included)
 "use client";
+import Image from "next/image";
 import Section from "./Section";
 import { track } from "@/lib/analytics";
 import { useViewTracker } from "@/hooks/useViewTracker";
@@ -12,7 +13,7 @@ export default function SiteFooter() {
   const ref = useViewTracker("view_footer");
 
   return (
-    <footer ref={ref as any} className="mt-10 border-t border-bart-gray/20 bg-white/90">
+    <footer ref={ref} className="mt-10 border-t border-bart-gray/20 bg-white/90">
       <Section className="py-8 flex flex-col sm:flex-row items-start sm:items-center gap-4 justify-between">
         <div>
           <p className="font-comic text-bart-black">Join the chaos, spread the bad art.</p>
@@ -27,11 +28,11 @@ export default function SiteFooter() {
             title="Follow us on X @BARTShitpost"
             onClick={() => track("footer_click_x_main")}
           >
-            <img
+            <Image
               src="/icons/x.svg"
               alt=""
-              width={20}
-              height={20}
+              width={64}
+              height={64}
               aria-hidden="true"
               className="h-16 w-16 shrink-0"
             />
@@ -46,11 +47,11 @@ export default function SiteFooter() {
             title="Join the X Community"
             onClick={() => track("footer_click_x_community")}
           >
-            <img
+            <Image
               src="/icons/c.svg"
               alt=""
-              width={20}
-              height={20}
+              width={64}
+              height={64}
               aria-hidden="true"
               className="h-16 w-16 shrink-0"
             />
@@ -65,11 +66,11 @@ export default function SiteFooter() {
             title="Track on Dexscreener"
             onClick={() => track("footer_click_dex")}
           >
-            <img
+            <Image
               src="/icons/dex.svg"
               alt=""
-              width={20}
-              height={20}
+              width={64}
+              height={64}
               aria-hidden="true"
               className="h-16 w-16 shrink-0"
             />

--- a/src/components/TeaserBanner.tsx
+++ b/src/components/TeaserBanner.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Section from "./Section";
 import TeaserBadge from "./TeaserBadge";
-import { track } from "@/lib/analytics";
+import { track, type AnalyticsEvent } from "@/lib/analytics";
 import { useEffect, useRef } from "react";
 
 type Variant = "hof" | "upload" | "voting" | "bonus";
@@ -32,16 +32,15 @@ export default function TeaserBanner({
   microcopy,
   backgroundTexture,
 }: TeaserProps) {
-  const hoverEvent =
+  const hoverEvent: AnalyticsEvent =
     variant === "bonus" ? "hover_glitch_bonus" : "hover_wobble_teaser";
-  const viewEvent =
-    variant === "hof"
-      ? "view_teaser_hof"
-      : variant === "upload"
-      ? "view_teaser_upload"
-      : variant === "voting"
-      ? "view_teaser_voting"
-      : "view_teaser_bonus";
+  const viewEventMap: Record<Variant, AnalyticsEvent> = {
+    hof: "view_teaser_hof",
+    upload: "view_teaser_upload",
+    voting: "view_teaser_voting",
+    bonus: "view_teaser_bonus",
+  };
+  const viewEvent = viewEventMap[variant];
 
   const animClass =
     variant === "hof"
@@ -61,7 +60,7 @@ export default function TeaserBanner({
       entries.forEach((e) => {
         if (!seen && e.isIntersecting) {
           seen = true;
-          track(viewEvent as any);
+          track(viewEvent);
           io.disconnect();
         }
       });
@@ -74,7 +73,7 @@ export default function TeaserBanner({
     <article
       ref={ref}
       data-variant={variant}
-      onMouseEnter={() => track(hoverEvent as any, { variant })}
+      onMouseEnter={() => track(hoverEvent, { variant })}
       className={`group relative w-full text-left rounded-lg border border-bart-gray/30 bg-white/90 shadow-sm overflow-hidden ${animClass}`}
       aria-label={title}
       role="group"


### PR DESCRIPTION
## Summary
- replace explicit `any` casts in ArtCard, Section, SiteFooter, and TeaserBanner with precise typings while keeping behaviour intact
- migrate Gallery, GalleryCard, ArtCard, and SiteFooter imagery to `next/image` to satisfy lint rules without altering layout
- clean up the unused Hero handler to resolve the no-unused-vars warning

## Testing
- `pnpm lint` *(fails: repository already contains unrelated lint errors outside the requested scope)*
- `pnpm build` *(fails: repository already contains unrelated lint errors outside the requested scope)*

------
https://chatgpt.com/codex/tasks/task_e_68d13b520ad4832f84c6c6ec80332c84