### PR TITLE
Fix lint issues and enforce ESLint during builds

### DIFF
--- a/lint-final.log
+++ b/lint-final.log
@@ -1,0 +1,1 @@
+✔ No ESLint warnings or errors

--- a/lint-initial.log
+++ b/lint-initial.log
@@ -1,0 +1,88 @@
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+./src/app/error.tsx
+27:11  Error: Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages  @next/next/no-html-link-for-pages
+
+./src/app/fonts.ts
+2:8  Error: 'localFont' is defined but never used.  @typescript-eslint/no-unused-vars
+
+./src/app/not-found.tsx
+9:9  Error: Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages  @next/next/no-html-link-for-pages
+
+./src/app/page.tsx
+27:34  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/components/AboutShort.tsx
+11:26  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/components/ArtCard.tsx
+30:48  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+31:48  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+32:49  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+33:50  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+56:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+
+./src/components/Gallery.tsx
+22:11  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+
+./src/components/GalleryCard.tsx
+22:7  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+
+./src/components/Hero.tsx
+10:9  Error: 'onHover' is assigned a value but never used.  @typescript-eslint/no-unused-vars
+
+./src/components/Section.tsx
+20:19  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+23:20  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/components/SiteFooter.tsx
+15:25  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+30:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+49:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+68:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+
+./src/components/TeaserBanner.tsx
+64:30  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+77:47  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/hooks/useViewTracker.tsx
+23:6  Warning: React Hook useEffect has a missing dependency: 'options'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
+
+./src/lib/api.ts
+51:11  Error: 'msg' is assigned a value but never used.  @typescript-eslint/no-unused-vars
+53:107  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+116:33  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/app/gallery/page.tsx
+7:26  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+8:26  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+./src/components/gallery/ArtworkCard.tsx
+15:10  Error: 'url' is assigned a value but never used.  @typescript-eslint/no-unused-vars
+16:11  Error: 'failed' is assigned a value but never used.  @typescript-eslint/no-unused-vars
+16:19  Error: 'onLoad' is assigned a value but never used.  @typescript-eslint/no-unused-vars
+16:27  Error: 'onError' is assigned a value but never used.  @typescript-eslint/no-unused-vars
+39:44  Error: Comments inside children section of tag should be placed inside braces  react/jsx-no-comment-textnodes
+47:27  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+52:7  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
+
+./src/components/gallery/GalleryGrid.tsx
+19:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+20:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+21:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+22:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+23:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+24:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+25:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+32:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+33:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+34:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+35:11  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+90:26  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+114:29  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+124:27  Error: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
+
+info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-    eslint: { ignoreDuringBuilds: true }, // Lint ignorieren beim build
-
   // ggf. weitere Optionen hier (images, redirects, etc.)
 };
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,16 +1,14 @@
-﻿'use client';
-// error.tsx 
-'use client';
+"use client";
 
-import { useEffect } from 'react';
+import Link from "next/link";
+import { useEffect } from "react";
 
-export default function Error({
-  error,
-  reset,
-}: {
+type ErrorProps = {
   error: Error & { digest?: string };
   reset: () => void;
-}) {
+};
+
+export default function Error({ error, reset }: ErrorProps) {
   useEffect(() => {
     console.error(error);
   }, [error]);
@@ -24,7 +22,9 @@ export default function Error({
           <button onClick={() => reset()} className="px-4 py-2 rounded-md border">
             Try again
           </button>
-          <a href="/" className="px-4 py-2 rounded-md border">Go home</a>
+          <Link href="/" className="px-4 py-2 rounded-md border">
+            Go home
+          </Link>
         </div>
       </div>
     </div>

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,5 +1,4 @@
 // src/app/fonts.ts
-import localFont from "next/font/local";
 import {
   Permanent_Marker,
   Comic_Neue,

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,11 +1,12 @@
 // app/gallery/page.tsx  (oder src/app/gallery/page.tsx – aber nur EINER der beiden Orte!)
-import GalleryCard from '@/components/GalleryCard';
-import StickerSheet from '@/components/StickerSheet';
-import copy from '@/content/copy.json';
+import GalleryCard from "@/components/GalleryCard";
+import StickerSheet from "@/components/StickerSheet";
+import copy from "@/content/copy.json";
 
 export default function GalleryPage() {
-  const title = (copy as any)?.gallery?.title ?? 'Gallery';
-  const sub   = (copy as any)?.gallery?.subtext ?? 'Explore the chaos.';
+  const {
+    gallery: { title, subtext },
+  } = copy;
 
   return (
     <div className="min-h-screen p-6">
@@ -13,7 +14,7 @@ export default function GalleryPage() {
         {title}
       </h1>
       <p className="text-lg text-[var(--bart-secondary-gray)] mb-12">
-        {sub}
+        {subtext}
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,12 +1,14 @@
-// not-found.tsx 
-// src/app/not-found.tsx
+import Link from "next/link";
+
 export default function NotFound() {
   return (
     <div className="min-h-[40vh] grid place-items-center p-8 text-center">
       <div className="max-w-md space-y-3">
         <h1 className="text-2xl font-semibold">404 — Not found</h1>
         <p className="opacity-70">Die Seite existiert nicht oder wurde verschoben.</p>
-        <a href="/" className="inline-block px-4 py-2 rounded-md border">Zur Startseite</a>
+        <Link href="/" className="inline-block px-4 py-2 rounded-md border">
+          Zur Startseite
+        </Link>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 // file: src/app/page.tsx  (nur relevanter Ausschnitt)
 import Hero from "@/components/Hero";
-import { TeaserRow } from "@/components/TeaserBanner";
+import { TeaserRow, type TeaserItem } from "@/components/TeaserBanner";
 import IntroBlurb from "@/components/IntroBlurb";   
 import GalleryGrid from "@/components/gallery/GalleryGrid";
 import AboutShort from "@/components/AboutShort";
@@ -8,12 +8,36 @@ import BelowGalleryCta from "@/components/BelowGalleryCta";
 import teasers from "@/content/teasers.json";
 
 export default function HomePage() {
-  const items = [
-    { variant: "hof",    title: teasers.hof.title,    manifest: teasers.hof.manifest,    microcopy: teasers.hof.microcopy,    icon: "/icons/spotlight.svg",    backgroundTexture: "/textures/paper_grain.png" },
-    { variant: "upload", title: teasers.upload.title, manifest: teasers.upload.manifest, microcopy: teasers.upload.microcopy, icon: "/icons/upload.svg",       backgroundTexture: "/textures/neon-swipes.png" },
-    { variant: "voting", title: teasers.voting.title, manifest: teasers.voting.manifest, microcopy: teasers.voting.microcopy, icon: "/icons/sticker-plus.svg", backgroundTexture: "/textures/scribble.png" },
-    { variant: "bonus",  title: teasers.bonus.title,  manifest: teasers.bonus.manifest,  microcopy: teasers.bonus.microcopy,  icon: "/icons/lock-glitch.svg",  backgroundTexture: "/textures/paper_grain.png" }
-  ] as const;
+  const items: TeaserItem[] = [
+    {
+      variant: "hof",
+      title: teasers.hof.title,
+      manifest: teasers.hof.manifest,
+      microcopy: teasers.hof.microcopy,
+      backgroundTexture: "/textures/paper_grain.png",
+    },
+    {
+      variant: "upload",
+      title: teasers.upload.title,
+      manifest: teasers.upload.manifest,
+      microcopy: teasers.upload.microcopy,
+      backgroundTexture: "/textures/neon-swipes.png",
+    },
+    {
+      variant: "voting",
+      title: teasers.voting.title,
+      manifest: teasers.voting.manifest,
+      microcopy: teasers.voting.microcopy,
+      backgroundTexture: "/textures/scribble.png",
+    },
+    {
+      variant: "bonus",
+      title: teasers.bonus.title,
+      manifest: teasers.bonus.manifest,
+      microcopy: teasers.bonus.microcopy,
+      backgroundTexture: "/textures/paper_grain.png",
+    },
+  ];
 
   return (
     <main>
@@ -24,7 +48,7 @@ export default function HomePage() {
         <GalleryGrid />
       </section>
       <BelowGalleryCta />
-      <TeaserRow items={items as any} />
+      <TeaserRow items={items} />
     </main>
   );
 }

--- a/src/components/AboutShort.tsx
+++ b/src/components/AboutShort.tsx
@@ -8,7 +8,7 @@ export default function AboutShort() {
   const ref = useViewTracker("view_about");
 
   return (
-    <Section ref={ref as any} id="about" className="py-12 md:py-16">
+    <Section ref={ref} id="about" className="py-12 md:py-16">
       <h2 className="font-marker text-3xl sm:text-4xl md:text-5xl leading-tight text-bart-black mb-4">
         About $BART
       </h2>

--- a/src/components/ArtCard.tsx
+++ b/src/components/ArtCard.tsx
@@ -1,16 +1,20 @@
 // file: src/components/ArtCard.tsx
 "use client";
+import Image from "next/image";
+import type { CSSProperties } from "react";
 
 type Color = "duo" | "pink" | "green";
+
+type CSSVarProperties = CSSProperties & Record<`--${string}`, string>;
 
 export type ArtCardProps = {
   src: string;
   alt?: string;
-  color?: Color;          // "duo" | "pink" | "green"
-  tiltDeg?: number;       // überschreibt --frame-tilt
-  className?: string;     // zusätzliche Wrapper-Klassen
+  color?: Color;
+  tiltDeg?: number;
+  className?: string;
   jitter?: {
-    left?: string;        // z.B. "0.6deg"
+    left?: string;
     right?: string;
     bottom?: string;
   };
@@ -24,36 +28,42 @@ export default function ArtCard({
   className = "",
   jitter,
 }: ArtCardProps) {
-  const styleVars = {
-    // CSS-Variablen für Rotation/Jitter
-    // werden auf dem Frame-Wrapper gesetzt
-    ...(tiltDeg !== undefined ? { ["--tilt" as any]: `${tiltDeg}deg` } : {}),
-    ...(jitter?.left   ? { ["--jitter-left" as any]: jitter.left }   : {}),
-    ...(jitter?.right  ? { ["--jitter-right" as any]: jitter.right } : {}),
-    ...(jitter?.bottom ? { ["--jitter-bottom" as any]: jitter.bottom } : {}),
-  };
+  const styleVars: CSSVarProperties = {};
 
-  const frameClass =
-    color === "duo"
-      ? "crayon-frame duo"
-      : "crayon-frame";
+  if (tiltDeg !== undefined) {
+    styleVars["--tilt"] = `${tiltDeg}deg`;
+  }
+  if (jitter?.left) {
+    styleVars["--jitter-left"] = jitter.left;
+  }
+  if (jitter?.right) {
+    styleVars["--jitter-right"] = jitter.right;
+  }
+  if (jitter?.bottom) {
+    styleVars["--jitter-bottom"] = jitter.bottom;
+  }
 
-  const dataColor =
-    color === "duo" ? {} : { "data-color": color };
+  const frameClass = color === "duo" ? "crayon-frame duo" : "crayon-frame";
+  const frameData = color === "duo" ? undefined : { "data-color": color };
 
   return (
     <div className={`art-card ${className}`}>
-      <div className="art-card__frame" style={styleVars as React.CSSProperties}>
-        <div className={frameClass} {...dataColor}>
-          {/* ======= Das eigentliche Markup der vier Rahmen-Seiten ======= */}
+      <div className="art-card__frame" style={styleVars}>
+        <div className={frameClass} {...(frameData ?? {})}>
           <div className="frame-top frame-side" />
           <div className="frame-right frame-side" />
           <div className="frame-bottom frame-side" />
           <div className="frame-left frame-side" />
 
-          {/* ======= Bild (gegenrotiert) ======= */}
           <div className="art-card__inner">
-            <img className="art-card__img" src={src} alt={alt} />
+            <Image
+              className="art-card__img"
+              src={src}
+              alt={alt}
+              width={512}
+              height={512}
+              unoptimized
+            />
           </div>
         </div>
       </div>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,13 +1,22 @@
-﻿'use client';
-import { motion } from 'framer-motion';
+"use client";
 
-const mockArtworks = [
-  { id: 1, src: '/images/placeholder.png', title: 'Untitled Chaos', artist: 'Bartschüler XY' },
-  { id: 1, src: '/images/placeholder_1.png', title: 'Untitled Chaos', artist: 'Bartschüler XY' },
-  { id: 2, src: '/images/placeholder_2.png', title: 'Neon Nightmare', artist: 'Anonymous Meme Maker' },
-  { id: 3, src: '/images/placeholder_3.png', title: 'Y-Head Madness', artist: 'Grotesk Genius' },
-  { id: 4, src: '/images/placeholder_4.png', title: 'Toilet Throne', artist: 'Irony Master' },
-  { id: 5, src: '/images/placeholder_5.png', title: 'Scribble Frenzy', artist: 'Chaos Creator' },
+import Image from "next/image";
+import { motion } from "framer-motion";
+
+type MockArtwork = {
+  id: number;
+  src: string;
+  title: string;
+  artist: string;
+};
+
+const mockArtworks: MockArtwork[] = [
+  { id: 1, src: "/images/placeholder.png", title: "Untitled Chaos", artist: "Bartschüler XY" },
+  { id: 2, src: "/images/placeholder_1.png", title: "Untitled Chaos", artist: "Bartschüler XY" },
+  { id: 3, src: "/images/placeholder_2.png", title: "Neon Nightmare", artist: "Anonymous Meme Maker" },
+  { id: 4, src: "/images/placeholder_3.png", title: "Y-Head Madness", artist: "Grotesk Genius" },
+  { id: 5, src: "/images/placeholder_4.png", title: "Toilet Throne", artist: "Irony Master" },
+  { id: 6, src: "/images/placeholder_5.png", title: "Scribble Frenzy", artist: "Chaos Creator" },
 ];
 
 export default function Gallery() {
@@ -17,9 +26,16 @@ export default function Gallery() {
         <motion.div
           key={art.id}
           className="relative bg-white p-4 rounded-lg shadow-lg transform rotate-1"
-          style={{ border: '6px solid transparent', borderImage: 'url(/textures/crayon-green.png) 30 round' }}
+          style={{ border: "6px solid transparent", borderImage: "url(/textures/crayon-green.png) 30 round" }}
         >
-          <img src={art.src} alt={art.title} className="w-full h-auto rounded" />
+          <Image
+            src={art.src}
+            alt={art.title}
+            width={600}
+            height={600}
+            className="w-full h-auto rounded"
+            priority={art.id === 1}
+          />
           <p className="mt-2 text-[var(--bart-secondary-gray)]">
             {art.title}, 2025 – {art.artist}
           </p>
@@ -29,7 +45,5 @@ export default function Gallery() {
         </motion.div>
       ))}
     </div>
-    
   );
 }
-

--- a/src/components/GalleryCard.tsx
+++ b/src/components/GalleryCard.tsx
@@ -1,25 +1,26 @@
-﻿'use client';
+"use client";
 
-import { motion } from 'framer-motion';
+import Image from "next/image";
+import { motion } from "framer-motion";
 
 export interface GalleryCardProps {
   src: string;
   title: string;
   artist: string;
-  layoutId?: string; // optional: für Motion-Übergänge
+  layoutId?: string;
 }
 
 export default function GalleryCard({ src, title, artist, layoutId }: GalleryCardProps) {
   return (
     <motion.div
       className="relative bg-white p-4 rounded-lg shadow-lg"
-      style={{ border: '6px solid transparent', borderImage: 'url(/textures/crayon-green.png) 30 round' }}
+      style={{ border: "6px solid transparent", borderImage: "url(/textures/crayon-green.png) 30 round" }}
       initial={{ rotate: 0 }}
       whileHover={{ rotate: [0, -1, 1, -1, 0] }}
       transition={{ duration: 0.5 }}
-      layoutId={layoutId ?? `card-${src}`} /* stabil durch src */
+      layoutId={layoutId ?? `card-${src}`}
     >
-      <img src={src} alt={title} className="w-full h-auto rounded" />
+      <Image src={src} alt={title} width={600} height={600} className="w-full h-auto rounded" />
       <p className="mt-2 text-sm text-[var(--bart-secondary-gray)]">
         {title}, 2025 – {artist}
       </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,12 +2,10 @@
 // file: src/components/Hero.tsx (unchanged from previous delivery)
 // ==============================
 "use client";
-import { track } from "@/lib/analytics";
 import Section from "./Section";
 
 
 export default function Hero() {
-  const onHover = () => track("tooltip_seen_soon", { source: "hero_cta" });
   return (
     <div className="relative z-[1]">
       <Section className="py-10 sm:py-14 md:py-16">

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,26 +1,34 @@
 // src/components/Section.tsx
-import React, { forwardRef } from "react";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type ElementType,
+  type ForwardedRef,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 
-type As = React.ElementType;
+type As = ElementType;
 
-type Props<T extends As = "section"> = {
+type SectionProps<T extends As = "section"> = {
   id?: string;
   className?: string;
   as?: T;
-  children?: React.ReactNode;
-} & Omit<React.ComponentPropsWithoutRef<T>, "as" | "className" | "id" | "children">;
+  children?: ReactNode;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "className" | "id" | "children">;
 
 function SectionInner<T extends As = "section">(
-  { id, className = "", as, children, ...rest }: Props<T>,
-  ref: React.Ref<Element>
+  { id, className = "", as, children, ...rest }: SectionProps<T>,
+  ref: ForwardedRef<ElementRef<T>>
 ) {
-  const Tag = (as || "section") as As;
+  const Tag = (as ?? "section") as T;
   return (
     <Tag
-      ref={ref as any}
+      ref={ref}
       id={id}
       className={`w-full max-w-[1240px] mx-auto px-4 sm:px-6 md:px-8 ${className}`}
-      {...(rest as any)}
+      {...rest}
     >
       {children}
     </Tag>
@@ -28,7 +36,7 @@ function SectionInner<T extends As = "section">(
 }
 
 const Section = forwardRef(SectionInner) as <T extends As = "section">(
-  p: Props<T> & { ref?: React.Ref<Element> }
-) => React.ReactElement | null;
+  props: SectionProps<T> & { ref?: ForwardedRef<ElementRef<T>> }
+) => ReactElement | null;
 
 export default Section;

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,5 +1,7 @@
 // file: src/components/SiteFooter.tsx  (UPDATE — icons included)
 "use client";
+import Image from "next/image";
+
 import Section from "./Section";
 import { track } from "@/lib/analytics";
 import { useViewTracker } from "@/hooks/useViewTracker";
@@ -12,7 +14,7 @@ export default function SiteFooter() {
   const ref = useViewTracker("view_footer");
 
   return (
-    <footer ref={ref as any} className="mt-10 border-t border-bart-gray/20 bg-white/90">
+    <footer ref={ref} className="mt-10 border-t border-bart-gray/20 bg-white/90">
       <Section className="py-8 flex flex-col sm:flex-row items-start sm:items-center gap-4 justify-between">
         <div>
           <p className="font-comic text-bart-black">Join the chaos, spread the bad art.</p>
@@ -27,12 +29,12 @@ export default function SiteFooter() {
             title="Follow us on X @sleepyofsol"
             onClick={() => track("footer_click_x_main")}
           >
-            <img
+            <Image
               src="/icons/x.svg"
               alt=""
-              width={20}
-              height={20}
-              aria-hidden="true"
+              width={64}
+              height={64}
+              aria-hidden
               className="h-16 w-16 shrink-0"
             />
             <span>Follow @sleepyofsol</span>
@@ -46,12 +48,12 @@ export default function SiteFooter() {
             title="Join the X Community"
             onClick={() => track("footer_click_x_community")}
           >
-            <img
+            <Image
               src="/icons/c.svg"
               alt=""
-              width={20}
-              height={20}
-              aria-hidden="true"
+              width={64}
+              height={64}
+              aria-hidden
               className="h-16 w-16 shrink-0"
             />
             <span>Join the X Community</span>
@@ -65,12 +67,12 @@ export default function SiteFooter() {
             title="Track on Dexscreener"
             onClick={() => track("footer_click_dex")}
           >
-            <img
+            <Image
               src="/icons/dex.svg"
               alt=""
-              width={20}
-              height={20}
-              aria-hidden="true"
+              width={64}
+              height={64}
+              aria-hidden
               className="h-16 w-16 shrink-0"
             />
             <span>Track the madness on Dexscreener</span>

--- a/src/components/gallery/ArtworkCard.tsx
+++ b/src/components/gallery/ArtworkCard.tsx
@@ -1,68 +1,46 @@
-// file: src/components/gallery/ArtworkCard.tsx  (UPDATE – ImageStatus + Fallback)
 "use client";
-import { useMemo, useState, useEffect } from "react";
-import { base64ToObjectUrl } from "@/lib/image";
-import { useImageStatus } from "@/hooks/useImageStatus";
-import "@/app/frames.css";
 
-type Artwork = {
-  id: string; title: string; author?: string;
-  mime: "image/png"|"image/jpeg"|"image/webp";
-  imageBase64: string; createdAt?: string;
+import { useMemo } from "react";
+
+import ArtCard from "@/components/ArtCard";
+import type { ArtCardProps } from "@/components/ArtCard";
+import type { TArtwork } from "@/lib/contracts";
+
+const colors: ArtCardProps["color"][] = ["duo", "pink", "green"];
+
+type ArtworkCardProps = {
+  item: TArtwork;
 };
 
-export default function ArtworkCard({ item }: { item: Artwork }) {
-  const [url, setUrl] = useState<string>("");
-  const { failed, onLoad, onError } = useImageStatus(item.id);
-  const color = useMemo<"green"|"pink">(() => (Math.random() < 0.5 ? "green" : "pink"), []);
-  const jitter = useMemo(() => ({
-    "--jitter-bottom": `${rand(-2,2)}deg`,
-    "--jitter-left":   `${rand(-2,2)}deg`,
-    "--jitter-right":  `${rand(-2,2)}deg`,
-  }) as React.CSSProperties, []);
+function randomAngle(min: number, max: number): string {
+  const value = Math.random() * (max - min) + min;
+  return `${value.toFixed(1)}deg`;
+}
 
-  useEffect(() => {
-    const u = base64ToObjectUrl(item.imageBase64);
-    setUrl(u);
-    return () => { if (u) URL.revokeObjectURL(u); };
-  }, [item.imageBase64]);
+export default function ArtworkCard({ item }: ArtworkCardProps) {
+  const color = useMemo(() => colors[Math.floor(Math.random() * colors.length)], []);
+  const jitter = useMemo(
+    () => ({
+      left: randomAngle(-2, 2),
+      right: randomAngle(-2, 2),
+      bottom: randomAngle(-2, 2),
+    }),
+    []
+  );
 
   return (
-    <figure className="crayon-frame group bg-white relative rounded-xl shadow-sm hover:shadow-md transition will-change-transform" data-color={color} style={jitter}>
-      <span className="frame-side frame-top" />
-      <span className="frame-side frame-right" />
-      <span className="frame-side frame-bottom" />
-      <span className="frame-side frame-left" />
-      <i className="tape tl" aria-hidden />
-      <i className="tape tr" aria-hidden />
-      <i className="tape bl" aria-hidden />
-      <i className="tape br" aria-hidden />
-
-      // relevante Struktur im JSX
-<div className="art-card">
-  <div
-    className={`
-      art-card__frame crayon-pink
-    `}
-    style={{ ['--tilt' as any]: '1.8deg' }} /* pro Karte variiert? dann hier anpassen */
-  >
-    <div className="art-card__tape">{/* optional: Tape-Dekor */}</div>
-
-    <div className="art-card__inner">
-      <img
-        className="art-card__img"
-        alt={item.title}
+    <figure className="space-y-2">
+      <ArtCard
         src={`data:${item.mime};base64,${item.imageBase64}`}
+        alt={item.title}
+        color={color}
+        jitter={jitter}
       />
-    </div>
-  </div>
-</div>
-
-
       <figcaption className="px-4 pb-3 font-comic text-sm text-bart-black">
-        {item.title}{item.author ? ` — ${item.author}` : ""}{item.createdAt ? `, ${new Date(item.createdAt).getFullYear()}` : ""}
+        {item.title}
+        {item.author ? ` — ${item.author}` : ""}
+        {item.createdAt ? `, ${new Date(item.createdAt).getFullYear()}` : ""}
       </figcaption>
     </figure>
   );
 }
-function rand(min: number, max: number) { return Math.round((Math.random() * (max - min) + min) * 10) / 10; }

--- a/src/hooks/useViewTracker.tsx
+++ b/src/hooks/useViewTracker.tsx
@@ -1,25 +1,38 @@
 // file: src/hooks/useViewTracker.ts
 "use client";
-import { useEffect, useRef } from "react";
-import { track, AnalyticsEvent } from "@/lib/analytics";
+import { useEffect, useMemo, useRef } from "react";
 
-export function useViewTracker(event: AnalyticsEvent, options: IntersectionObserverInit = { threshold: 0.4 }) {
+import { track, type AnalyticsEvent } from "@/lib/analytics";
+
+const DEFAULT_OPTIONS: IntersectionObserverInit = { threshold: 0.4 };
+
+export function useViewTracker(event: AnalyticsEvent, options?: IntersectionObserverInit) {
   const ref = useRef<HTMLElement | null>(null);
+  const observerOptions = useMemo<IntersectionObserverInit>(() => ({
+    ...DEFAULT_OPTIONS,
+    ...options,
+  }), [options]);
+
   useEffect(() => {
     const el = ref.current;
-    if (!el || typeof window === "undefined") return;
+    if (!el || typeof window === "undefined") {
+      return;
+    }
+
     let seen = false;
     const io = new IntersectionObserver((entries) => {
-      entries.forEach((e) => {
-        if (!seen && e.isIntersecting) {
+      entries.forEach((entry) => {
+        if (!seen && entry.isIntersecting) {
           seen = true;
           track(event);
           io.disconnect();
         }
       });
-    }, options);
+    }, observerOptions);
+
     io.observe(el);
     return () => io.disconnect();
-  }, [event, options.root, options.rootMargin, options.threshold]);
+  }, [event, observerOptions]);
+
   return ref;
 }


### PR DESCRIPTION
## Summary
- remove the `eslint.ignoreDuringBuilds` escape hatch so builds respect lint failures
- replace raw anchors, `any` casts, and unused imports with typed APIs and `next/link`
- migrate gallery, footer, and art card components to `next/image` and stricter types, updating supporting hooks and API helpers
- capture the failing and passing lint outputs for traceability

## Testing
- `pnpm next lint --no-inline-config --max-warnings=0`

------
https://chatgpt.com/codex/tasks/task_e_68d1bfb48d54832faec33d931bd70984